### PR TITLE
Rename project from kubectl-prune to kubectl-reap

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
-# kubectl-prune
+# kubectl-reap
 
 [![actions-workflow-test][actions-workflow-test-badge]][actions-workflow-test]
 [![release][release-badge]][release]
 [![pkg.go.dev][pkg.go.dev-badge]][pkg.go.dev]
 [![license][license-badge]][license]
 
-`kubectl-prune` is a kubectl plugin that deletes unused Kubernetes resources.
+`kubectl-reap` is a kubectl plugin that deletes unused Kubernetes resources.
 
 Supported resources:
 
@@ -22,12 +22,12 @@ Since this plugin supports dry-run as described below, it also helps you to find
 
 ## Installation
 
-Download precompiled binaries from [GitHub Releases](https://github.com/micnncim/kubectl-prune/releases).
+Download precompiled binaries from [GitHub Releases](https://github.com/micnncim/kubectl-reap/releases).
 
 If you want to build a binary from source:
 
 ```
-$ GO111MODULE=on go get github.com/micnncim/kubectl-prune/cmd/kubectl-prune
+$ GO111MODULE=on go get github.com/micnncim/kubectl-reap/cmd/kubectl-reap
 ```
 
 ## Examples
@@ -45,7 +45,7 @@ nginx-54565674c6-v7xw9   0/1     Failed      0          30s
 nginx-54565674c6-wwb6m   0/1     Unknown     0          40s
 job-kqpxc                0/1     Completed   0          50s
 
-$ kubectl prune po
+$ kubectl reap po
 pod/nginx-54565674c6-t8hnm deleted
 pod/nginx-54565674c6-v7xw9 deleted
 pod/nginx-54565674c6-wwb6m deleted
@@ -88,7 +88,7 @@ $ kubectl get po
 NAME                     READY   STATUS              RESTARTS   AGE
 nginx                    1/1     Running             0          0m40s
 
-$ kubectl prune cm --dry-run=client
+$ kubectl reap cm --ury-run=client
 configmap/config-2 deleted (dry run)
 
 $ kubectl get cm
@@ -96,7 +96,7 @@ NAME       DATA   AGE
 config-1   1      1m15s
 config-2   1      1m10s
 
-$ kubectl prune cm
+$ kubectl reap cm
 configmap/config-2 deleted
 
 $ kubectl get cm
@@ -109,7 +109,7 @@ config-1   1      1m30s
 You can choose which resource you will delete one by one by interactive mode.
 
 ```console
-$ kubectl prune cm --interactive # or '-i'
+$ kubectl reap cm --interactive # or '-i'
 ? Are you sure to delete configmap/test-cm-1? Yes
 configmap/test-cm-1 deleted
 ? Are you sure to delete configmap/test-cm-2? No
@@ -120,7 +120,7 @@ configmap/test-cm-3 deleted
 ## Usage
 
 ```console
-$ kubectl prune --help
+$ kubectl reap --help
 
 Delete unused resources. Supported resources:
 
@@ -134,21 +134,21 @@ Delete unused resources. Supported resources:
 - HorizontalPodAutoscalers (not targeting any resources)
 
 Usage:
-  kubectl prune RESOURCE_TYPE [flags]
+  kubectl reap RESOURCE_TYPE [flags]
 
 Examples:
 
   # Delete ConfigMaps not mounted on any Pods and in the current namespace and context
-  $ kubectl prune configmaps
+  $ kubectl reap configmaps
 
   # Delete unused ConfigMaps and Secrets in the namespace/my-namespace and context/my-context
-  $ kubectl prune cm,secret -n my-namespace --context my-context
+  $ kubectl reap cm,secret -n my-namespace --context my-context
 
   # Delete ConfigMaps not mounted on any Pods and across all namespace
-  $ kubectl prune cm --all-namespaces
+  $ kubectl reap cm --all-namespaces
 
   # Delete Pods whose status is not Running as client-side dry-run
-  $ kubectl prune po --dry-run=client
+  $ kubectl reap po --dry-run=client
 
 Flags:
   -A, --all-namespaces                 If true, delete the targeted resources across all namespace except kube-system
@@ -204,14 +204,14 @@ this plugin provides more flexible, easy way to delete resources.
 
 <!-- badge links -->
 
-[actions-workflow-test]: https://github.com/micnncim/kubectl-prune/actions?query=workflow%3ATest
-[actions-workflow-test-badge]: https://img.shields.io/github/workflow/status/micnncim/kubectl-prune/Test?label=Test&style=for-the-badge&logo=github
+[actions-workflow-test]: https://github.com/micnncim/kubectl-reap/actions?query=workflow%3ATest
+[actions-workflow-test-badge]: https://img.shields.io/github/workflow/status/micnncim/kubectl-reap/Test?label=Test&style=for-the-badge&logo=github
 
-[release]: https://github.com/micnncim/kubectl-prune/releases
-[release-badge]: https://img.shields.io/github/v/release/micnncim/kubectl-prune?style=for-the-badge&logo=github
+[release]: https://github.com/micnncim/kubectl-reap/releases
+[release-badge]: https://img.shields.io/github/v/release/micnncim/kubectl-reap?style=for-the-badge&logo=github
 
-[pkg.go.dev]: https://pkg.go.dev/github.com/micnncim/kubectl-prune?tab=overview
+[pkg.go.dev]: https://pkg.go.dev/github.com/micnncim/kubectl-reap?tab=overview
 [pkg.go.dev-badge]: https://img.shields.io/badge/pkg.go.dev-reference-02ABD7?style=for-the-badge&logoWidth=25&logo=data%3Aimage%2Fsvg%2Bxml%3Bbase64%2CPHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9Ijg1IDU1IDEyMCAxMjAiPjxwYXRoIGZpbGw9IiMwMEFERDgiIGQ9Ik00MC4yIDEwMS4xYy0uNCAwLS41LS4yLS4zLS41bDIuMS0yLjdjLjItLjMuNy0uNSAxLjEtLjVoMzUuN2MuNCAwIC41LjMuMy42bC0xLjcgMi42Yy0uMi4zLS43LjYtMSAuNmwtMzYuMi0uMXptLTE1LjEgOS4yYy0uNCAwLS41LS4yLS4zLS41bDIuMS0yLjdjLjItLjMuNy0uNSAxLjEtLjVoNDUuNmMuNCAwIC42LjMuNS42bC0uOCAyLjRjLS4xLjQtLjUuNi0uOS42bC00Ny4zLjF6bTI0LjIgOS4yYy0uNCAwLS41LS4zLS4zLS42bDEuNC0yLjVjLjItLjMuNi0uNiAxLS42aDIwYy40IDAgLjYuMy42LjdsLS4yIDIuNGMwIC40LS40LjctLjcuN2wtMjEuOC0uMXptMTAzLjgtMjAuMmMtNi4zIDEuNi0xMC42IDIuOC0xNi44IDQuNC0xLjUuNC0xLjYuNS0yLjktMS0xLjUtMS43LTIuNi0yLjgtNC43LTMuOC02LjMtMy4xLTEyLjQtMi4yLTE4LjEgMS41LTYuOCA0LjQtMTAuMyAxMC45LTEwLjIgMTkgLjEgOCA1LjYgMTQuNiAxMy41IDE1LjcgNi44LjkgMTIuNS0xLjUgMTctNi42LjktMS4xIDEuNy0yLjMgMi43LTMuN2gtMTkuM2MtMi4xIDAtMi42LTEuMy0xLjktMyAxLjMtMy4xIDMuNy04LjMgNS4xLTEwLjkuMy0uNiAxLTEuNiAyLjUtMS42aDM2LjRjLS4yIDIuNy0uMiA1LjQtLjYgOC4xLTEuMSA3LjItMy44IDEzLjgtOC4yIDE5LjYtNy4yIDkuNS0xNi42IDE1LjQtMjguNSAxNy05LjggMS4zLTE4LjktLjYtMjYuOS02LjYtNy40LTUuNi0xMS42LTEzLTEyLjctMjIuMi0xLjMtMTAuOSAxLjktMjAuNyA4LjUtMjkuMyA3LjEtOS4zIDE2LjUtMTUuMiAyOC0xNy4zIDkuNC0xLjcgMTguNC0uNiAyNi41IDQuOSA1LjMgMy41IDkuMSA4LjMgMTEuNiAxNC4xLjYuOS4yIDEuNC0xIDEuN3oiLz48cGF0aCBmaWxsPSIjMDBBREQ4IiBkPSJNMTg2LjIgMTU0LjZjLTkuMS0uMi0xNy40LTIuOC0yNC40LTguOC01LjktNS4xLTkuNi0xMS42LTEwLjgtMTkuMy0xLjgtMTEuMyAxLjMtMjEuMyA4LjEtMzAuMiA3LjMtOS42IDE2LjEtMTQuNiAyOC0xNi43IDEwLjItMS44IDE5LjgtLjggMjguNSA1LjEgNy45IDUuNCAxMi44IDEyLjcgMTQuMSAyMi4zIDEuNyAxMy41LTIuMiAyNC41LTExLjUgMzMuOS02LjYgNi43LTE0LjcgMTAuOS0yNCAxMi44LTIuNy41LTUuNC42LTggLjl6bTIzLjgtNDAuNGMtLjEtMS4zLS4xLTIuMy0uMy0zLjMtMS44LTkuOS0xMC45LTE1LjUtMjAuNC0xMy4zLTkuMyAyLjEtMTUuMyA4LTE3LjUgMTcuNC0xLjggNy44IDIgMTUuNyA5LjIgMTguOSA1LjUgMi40IDExIDIuMSAxNi4zLS42IDcuOS00LjEgMTIuMi0xMC41IDEyLjctMTkuMXoiLz48L3N2Zz4=
 
 [license]: LICENSE
-[license-badge]: https://img.shields.io/github/license/micnncim/kubectl-prune?style=for-the-badge
+[license-badge]: https://img.shields.io/github/license/micnncim/kubectl-reap?style=for-the-badge

--- a/cmd/kubectl-reap/main.go
+++ b/cmd/kubectl-reap/main.go
@@ -6,11 +6,11 @@ import (
 
 	"k8s.io/cli-runtime/pkg/genericclioptions"
 
-	"github.com/micnncim/kubectl-prune/pkg/cmd"
+	"github.com/micnncim/kubectl-reap/pkg/cmd"
 )
 
 func main() {
-	cmd := cmd.NewCmdPrune(genericclioptions.IOStreams{
+	cmd := cmd.NewCmdReap(genericclioptions.IOStreams{
 		In:     os.Stdin,
 		Out:    os.Stdout,
 		ErrOut: os.Stderr,

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/micnncim/kubectl-prune
+module github.com/micnncim/kubectl-reap
 
 go 1.14
 

--- a/pkg/cmd/cmd.go
+++ b/pkg/cmd/cmd.go
@@ -21,14 +21,14 @@ import (
 	cmdutil "k8s.io/kubectl/pkg/cmd/util"
 	cmdwait "k8s.io/kubectl/pkg/cmd/wait"
 
-	"github.com/micnncim/kubectl-prune/pkg/determiner"
-	"github.com/micnncim/kubectl-prune/pkg/prompt"
-	"github.com/micnncim/kubectl-prune/pkg/resource"
-	"github.com/micnncim/kubectl-prune/pkg/version"
+	"github.com/micnncim/kubectl-reap/pkg/determiner"
+	"github.com/micnncim/kubectl-reap/pkg/prompt"
+	"github.com/micnncim/kubectl-reap/pkg/resource"
+	"github.com/micnncim/kubectl-reap/pkg/version"
 )
 
 const (
-	pruneShortDescription = `
+	reapShortDescription = `
 Delete unused resources. Supported resources:
 
 - Pods (whose status is not Running)
@@ -41,18 +41,18 @@ Delete unused resources. Supported resources:
 - HorizontalPodAutoscalers (not targeting any resources)
 `
 
-	pruneExample = `
+	reapExample = `
   # Delete ConfigMaps not mounted on any Pods and in the current namespace and context
-  $ kubectl prune configmaps
+  $ kubectl reap configmaps
 
   # Delete unused ConfigMaps and Secrets in the namespace/my-namespace and context/my-context
-  $ kubectl prune cm,secret -n my-namespace --context my-context
+  $ kubectl reap cm,secret -n my-namespace --context my-context
 
   # Delete ConfigMaps not mounted on any Pods and across all namespace
-  $ kubectl prune cm --all-namespaces
+  $ kubectl reap cm --all-namespaces
 
   # Delete Pods whose status is not Running as client-side dry-run
-  $ kubectl prune po --dry-run=client`
+  $ kubectl reap po --dry-run=client`
 
 	// printedOperationTypeDeleted is used when printer outputs the result of operations.
 	printedOperationTypeDeleted = "deleted"
@@ -101,13 +101,13 @@ func NewOptions(ioStreams genericclioptions.IOStreams) *Options {
 	}
 }
 
-func NewCmdPrune(streams genericclioptions.IOStreams) *cobra.Command {
+func NewCmdReap(streams genericclioptions.IOStreams) *cobra.Command {
 	o := NewOptions(streams)
 
 	cmd := &cobra.Command{
-		Use:     "kubectl prune RESOURCE_TYPE",
-		Short:   pruneShortDescription,
-		Example: pruneExample,
+		Use:     "kubectl reap RESOURCE_TYPE",
+		Short:   reapShortDescription,
+		Example: reapExample,
 		Run: func(cmd *cobra.Command, args []string) {
 			if o.showVersion {
 				o.Infof("%s (%s)\n", version.Version, version.Revision)

--- a/pkg/cmd/cmd_test.go
+++ b/pkg/cmd/cmd_test.go
@@ -17,7 +17,7 @@ import (
 	cmdutil "k8s.io/kubectl/pkg/cmd/util"
 	"k8s.io/kubectl/pkg/scheme"
 
-	"github.com/micnncim/kubectl-prune/pkg/determiner"
+	"github.com/micnncim/kubectl-reap/pkg/determiner"
 )
 
 func TestOptions_Run(t *testing.T) {

--- a/pkg/determiner/determiner_test.go
+++ b/pkg/determiner/determiner_test.go
@@ -15,7 +15,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	cliresource "k8s.io/cli-runtime/pkg/resource"
 
-	"github.com/micnncim/kubectl-prune/pkg/resource"
+	"github.com/micnncim/kubectl-reap/pkg/resource"
 )
 
 func Test_determiner_DetermineDeletion(t *testing.T) {
@@ -300,11 +300,11 @@ func Test_determiner_DetermineDeletion(t *testing.T) {
 
 			got, err := d.DetermineDeletion(context.Background(), tt.args.info)
 			if (err != nil) != tt.wantErr {
-				t.Errorf("determiner.determinePrune() error = %v, wantErr %v", err, tt.wantErr)
+				t.Errorf("determiner.DetermineDeletion() error = %v, wantErr %v", err, tt.wantErr)
 				return
 			}
 			if got != tt.want {
-				t.Errorf("determiner.determinePrune() = %v, want %v", got, tt.want)
+				t.Errorf("determiner.DetermineDeletion() = %v, want %v", got, tt.want)
 			}
 		})
 	}


### PR DESCRIPTION
To add [krew-index](https://github.com/kubernetes-sigs/krew-index), we should rename the project so that this plugin name makes sense and become unlikely to collide kubectl future commands.

For details: https://github.com/kubernetes-sigs/krew-index/pull/793